### PR TITLE
Fix the scanner issue

### DIFF
--- a/heft/MpedDevice.mm
+++ b/heft/MpedDevice.mm
@@ -506,6 +506,11 @@ enum eSignConditions{
 
     // default timeoutvalue is 60 seconds
     long timeoutSecondsParameter = timeoutSeconds == 0 ? 60 : timeoutSeconds;
+    if (timeoutSecondsParameter > 65535)
+    {
+        // the max value supported by the reader
+        timeoutSecondsParameter = 65535;
+    }
     NSString* timeoutSecondsString = [NSString stringWithFormat:
                     @"<timeoutSeconds>"
                     @"%ld"


### PR DESCRIPTION
Update:
- Add all parameters to the scanner XML command, before default values were not sent
- Set timeout to 60 seconds default value if parameter is 0
  Fix:
- set cancelAllowed = true when cancel is called since no message is retrieved from the reader
  until a barcode is scanned. This fixes the error where users can't stop/cancel scanning unless
  a barcode is scanned.
