### PR TITLE
Fixed the log enum

### DIFF
--- a/heft/HeftClient.h
+++ b/heft/HeftClient.h
@@ -16,12 +16,13 @@
 /**
  @brief param values for HeftClient -(BOOL)logSetLevel:(eLogLevel)level.
  */
-typedef enum{
-	eLogNone
-	, eLogInfo
-	, eLogFull
-	, eLogDebug
-} eLogLevel;
+typedef NS_ENUM(NSUInteger, eLogLevel){
+	eLogNone                    // 0
+    , eLogError                 // 1
+	, eLogInfo                  // 2
+	, eLogFull                  // 3
+	, eLogDebug                 // 4
+};
 
 /** 
 @brief HeftClient protocol methods.

--- a/heft/HeftManager.h
+++ b/heft/HeftManager.h
@@ -142,7 +142,6 @@
 
 - (void)cleanup;
 
-- (void)timerCallback;
 
 @end
 


### PR DESCRIPTION
It was missing the eLogError value, which means every value except
eLogNone was out of sync with the reader.
Unrelated: Removed one unused definition from the header file.