### PR TITLE
Check if stream is still valid during a background process

### DIFF
--- a/Library/heft/HeftConnection.mm
+++ b/Library/heft/HeftConnection.mm
@@ -228,6 +228,11 @@ bool isStatusAnError (NSStreamStatus status)
     {
         if ([outputData length] > 0)
         {
+            // Check if current stream is still valid during background process
+            if (outputStream == nil || outputStream.delegate == nil) {
+                return;
+            }
+            
             if ([outputStream hasSpaceAvailable] == NO)
             {
                 return; // since we could not write all of the data, we wait for the next event


### PR DESCRIPTION
Checks if the stream and delegate is still. This fixes [EAConnection close] crash when the device goes to the background.